### PR TITLE
Enable Firebase server side

### DIFF
--- a/app/lib/firebase.ts
+++ b/app/lib/firebase.ts
@@ -2,6 +2,7 @@ import { initializeApp, getApps, FirebaseApp } from 'firebase/app';
 import { getAuth, Auth } from 'firebase/auth';
 import { getFirestore, Firestore } from 'firebase/firestore';
 import { getStorage, FirebaseStorage } from 'firebase/storage';
+import * as admin from 'firebase-admin';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -9,28 +10,36 @@ const firebaseConfig = {
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
   storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase only on the client side
 let app: FirebaseApp | undefined;
 let auth: Auth | undefined;
-let db: Firestore | undefined;
 let storage: FirebaseStorage | undefined;
+let db: Firestore | admin.firestore.Firestore | undefined;
 
-if (typeof window !== 'undefined') {
-  // Only initialize Firebase on the client side
+if (typeof window === 'undefined') {
+  if (!admin.apps.length) {
+    const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT_KEY
+      ? JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY)
+      : undefined;
+    admin.initializeApp({
+      credential: serviceAccount
+        ? admin.credential.cert(serviceAccount)
+        : admin.credential.applicationDefault(),
+    });
+  }
+  db = admin.firestore();
+} else {
   if (!getApps().length) {
     app = initializeApp(firebaseConfig);
   } else {
     app = getApps()[0];
   }
-  
-  // Initialize Firebase services
   auth = getAuth(app);
   db = getFirestore(app);
   storage = getStorage(app);
 }
 
 export { auth, db, storage };
-export default app; 
+export default app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@stripe/react-stripe-js": "^3.7.0",
         "@stripe/stripe-js": "^7.4.0",
         "firebase": "^11.10.0",
+        "firebase-admin": "^11.10.0",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.4.0",
     "firebase": "^11.10.0",
+    "firebase-admin": "^11.10.0",
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- allow server-side Firebase initialization via firebase-admin
- export `db` to allow Firestore access in API routes
- add firebase-admin dependency

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700b1ec4dc832bb274fc0e5ad058d4