### PR TITLE
Remove duplicate auth provider

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { AdminAuthProvider } from '../contexts/AdminAuthContext';
 import { useAdminAuth } from '../contexts/AdminAuthContext';
 import { useRouter, usePathname } from 'next/navigation';
 import { useEffect } from 'react';
@@ -83,10 +82,10 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   return (
-    <AdminAuthProvider>
-      <AdminAuthGuard>
-        {children}
-      </AdminAuthGuard>
-    </AdminAuthProvider>
+    <AdminAuthGuard>
+      {children}
+    </AdminAuthGuard>
   );
-} 
+}
+
+


### PR DESCRIPTION
## Summary
- remove `AdminAuthProvider` wrapper from admin layout so it uses the provider declared in `app/layout.tsx`

## Testing
- `npm install`
- `NEXT_DISABLE_FONT_DOWNLOADS=1 npm run build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_6875add8e2d8832ba4bceece37cea201