### PR TITLE
Update Stripe API version

### DIFF
--- a/app/api/stripe/checkout-session.ts
+++ b/app/api/stripe/checkout-session.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-  apiVersion: '2025-06-30.basil',
+  apiVersion: '2022-11-15',
 });
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
## Summary
- use Stripe API version `2022-11-15`

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: unable to fetch fonts)*
- `node` test Stripe call *(fails: connection to api.stripe.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875ade3c958832b9d3123cf036ae675