### PR TITLE
Remove verbose logs

### DIFF
--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -5,11 +5,17 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string);
 
 // This endpoint is intended to handle POST requests from the frontend and send a POST to Stripe
 export async function POST(req: NextRequest) {
-  console.log('[DEBUG] POST handler called for /api/stripe/create-payment-intent');
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[DEBUG] POST handler called for /api/stripe/create-payment-intent');
+  }
   try {
-    console.log('[DEBUG] Request method:', req.method);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[DEBUG] Request method:', req.method);
+    }
     const body = await req.json();
-    console.log('[DEBUG] Request body:', body);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[DEBUG] Request body:', body);
+    }
     const { items, customerName, customerEmail, customerPhone } = body;
 
     // Calculate total amount in cents
@@ -29,7 +35,9 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    console.log('[DEBUG] PaymentIntent created:', paymentIntent.id);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[DEBUG] PaymentIntent created:', paymentIntent.id);
+    }
     return NextResponse.json({ clientSecret: paymentIntent.client_secret });
   } catch (err: any) {
     console.error('[DEBUG] Stripe PaymentIntent error:', err);

--- a/app/api/stripe/webhook.ts
+++ b/app/api/stripe/webhook.ts
@@ -28,13 +28,17 @@ export async function POST(req: NextRequest) {
     return new NextResponse(`Webhook Error: ${err.message}`, { status: 400 });
   }
 
-  console.log('Webhook received:', event.type);
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('Webhook received:', event.type);
+  }
 
   if (event.type === 'payment_intent.succeeded') {
     const paymentIntent = event.data.object as Stripe.PaymentIntent;
     const metadata = paymentIntent.metadata || {};
     
-    console.log('Processing payment_intent.succeeded:', paymentIntent.id);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Processing payment_intent.succeeded:', paymentIntent.id);
+    }
     
     try {
       // Validate required metadata
@@ -65,7 +69,9 @@ export async function POST(req: NextRequest) {
       };
       const orderId = await createOrder(orderData);
 
-      console.log('Order created successfully:', orderId);
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('Order created successfully:', orderId);
+      }
       
       // You could also send a confirmation email here
       // await sendOrderConfirmationEmail(paymentIntent.receipt_email, orderId);
@@ -85,7 +91,9 @@ export async function POST(req: NextRequest) {
   // Handle other webhook events if needed
   if (event.type === 'payment_intent.payment_failed') {
     const paymentIntent = event.data.object as Stripe.PaymentIntent;
-    console.log('Payment failed:', paymentIntent.id);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Payment failed:', paymentIntent.id);
+    }
     // You could send a failure notification here
   }
 

--- a/app/components/Checkout.tsx
+++ b/app/components/Checkout.tsx
@@ -46,21 +46,25 @@ function CheckoutForm({ isOpen, onClose }: CheckoutProps) {
   // Debug Stripe key and promise
   useEffect(() => {
     const key = STRIPE_PUBLISHABLE_KEY;
-    console.log('Stripe key debug:', {
-      key: key ? 'Present' : 'Missing',
-      keyLength: key?.length || 0,
-      keyStart: key?.substring(0, 10) + '...' || 'N/A',
-      keyType: key?.startsWith('pk_test_') ? 'Test' : key?.startsWith('pk_live_') ? 'Live' : 'Invalid',
-      envVars: {
-        hasKey: !!STRIPE_PUBLISHABLE_KEY,
-        hasSecret: !!process.env.STRIPE_SECRET_KEY,
-        hasWebhook: !!process.env.STRIPE_WEBHOOK_SECRET
-      }
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Stripe key debug:', {
+        key: key ? 'Present' : 'Missing',
+        keyLength: key?.length || 0,
+        keyStart: key?.substring(0, 10) + '...' || 'N/A',
+        keyType: key?.startsWith('pk_test_') ? 'Test' : key?.startsWith('pk_live_') ? 'Live' : 'Invalid',
+        envVars: {
+          hasKey: !!STRIPE_PUBLISHABLE_KEY,
+          hasSecret: !!process.env.STRIPE_SECRET_KEY,
+          hasWebhook: !!process.env.STRIPE_WEBHOOK_SECRET
+        }
+      });
+    }
 
     // Test the stripe promise
     stripePromise.then((stripeInstance) => {
-      console.log('Stripe promise resolved:', !!stripeInstance);
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('Stripe promise resolved:', !!stripeInstance);
+      }
       setStripeLoadError(null);
     }).catch((error) => {
       console.error('Stripe promise failed:', error);
@@ -70,11 +74,13 @@ function CheckoutForm({ isOpen, onClose }: CheckoutProps) {
 
   // Check if Stripe is ready
   useEffect(() => {
-    console.log('Stripe debug:', { 
-      stripe: !!stripe, 
-      elements: !!elements,
-      stripeLoadError: stripeLoadError 
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Stripe debug:', {
+        stripe: !!stripe,
+        elements: !!elements,
+        stripeLoadError: stripeLoadError
+      });
+    }
     
     if (stripe && elements) {
       setIsStripeReady(true);
@@ -94,10 +100,12 @@ function CheckoutForm({ isOpen, onClose }: CheckoutProps) {
   // Force show card element after 5 seconds if not ready
   useEffect(() => {
     if (!isStripeReady) {
-      const timer = setTimeout(() => {
-        console.log('Forcing CardElement to show after timeout');
-        setForceShowCard(true);
-      }, 5000);
+        const timer = setTimeout(() => {
+          if (process.env.NODE_ENV !== 'production') {
+            console.log('Forcing CardElement to show after timeout');
+          }
+          setForceShowCard(true);
+        }, 5000);
       
       return () => clearTimeout(timer);
     }
@@ -201,7 +209,9 @@ function CheckoutForm({ isOpen, onClose }: CheckoutProps) {
             
             if (orderCheckResponse.ok) {
               const orderData = await orderCheckResponse.json();
-              console.log('Order verified:', orderData.orderId);
+              if (process.env.NODE_ENV !== 'production') {
+                console.log('Order verified:', orderData.orderId);
+              }
             } else {
               console.warn('Order verification failed, but payment succeeded');
             }


### PR DESCRIPTION
## Summary
- gate Stripe debug logs behind NODE_ENV checks in Checkout form
- wrap log statements in Stripe server routes

## Testing
- `npm run lint` *(fails: project not configured)*
- `npm run build` *(fails: cannot fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6875adea0774832ba520526cb3c8b458