### PR TITLE
Remove unused SVGR loader

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Enable Turbopack for faster builds (moved from experimental.turbo)
-  turbopack: {
-    rules: {
-      '*.svg': {
-        loaders: ['@svgr/webpack'],
-        as: '*.js',
-      },
-    },
-  },
-
   // Image optimization settings
   images: {
     // Allow images from external domains if needed


### PR DESCRIPTION
## Summary
- remove Turbopack SVG loader configuration from `next.config.ts`

The project doesn't contain any SVGs so the special loader isn't needed.

## Testing
- `npm install`
- `npm run build` *(fails: next/font unable to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6875addef10c832ba821f4a9adfc39d1