### PR TITLE
Fix Firebase initialization for server code

### DIFF
--- a/app/lib/firebase.ts
+++ b/app/lib/firebase.ts
@@ -12,25 +12,13 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
 };
 
-// Initialize Firebase only on the client side
-let app: FirebaseApp | undefined;
-let auth: Auth | undefined;
-let db: Firestore | undefined;
-let storage: FirebaseStorage | undefined;
+// Initialize Firebase app regardless of environment
+const app: FirebaseApp = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 
-if (typeof window !== 'undefined') {
-  // Only initialize Firebase on the client side
-  if (!getApps().length) {
-    app = initializeApp(firebaseConfig);
-  } else {
-    app = getApps()[0];
-  }
-  
-  // Initialize Firebase services
-  auth = getAuth(app);
-  db = getFirestore(app);
-  storage = getStorage(app);
-}
+// Firebase services
+const auth: Auth = getAuth(app);
+const db: Firestore = getFirestore(app);
+const storage: FirebaseStorage = getStorage(app);
 
 export { auth, db, storage };
-export default app; 
+export default app;


### PR DESCRIPTION
## Summary
- init Firebase regardless of client or server

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687700f549c8832bbe9d473cc5d9f79d