### PR TITLE
Move Stripe webhook handler

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { createOrder } from '../../lib/products';
+import { createOrder } from '../../../lib/products';
 import { serverTimestamp, Timestamp } from 'firebase/firestore';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string);


### PR DESCRIPTION
## Summary
- move `app/api/stripe/webhook.ts` to new App Router folder `app/api/stripe/webhook/route.ts`
- update import path for `createOrder`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687700f47e18832bb5c5af9e7d170b20